### PR TITLE
Fix all open bugs and implement issues #10 and #11

### DIFF
--- a/src/anking_tables/__init__.py
+++ b/src/anking_tables/__init__.py
@@ -57,7 +57,7 @@ def open_main_window_func(editor):
 
 
 def add_buttons(buttons, editor):
-    icon_path = os.path.join(os.path.dirname(__file__), 'icons', 'table_editor_toolbar_dark.png' if is_night_mode else 'table_editor_toolbar_light.png')
+    icon_path = os.path.join(os.path.dirname(__file__), 'icons', 'table_editor_toolbar_dark.png' if is_night_mode() else 'table_editor_toolbar_light.png')
     btn = editor.addButton(
         icon=icon_path,
         cmd="OpenMainWindow",

--- a/src/anking_tables/main_window.py
+++ b/src/anking_tables/main_window.py
@@ -93,7 +93,7 @@ class HtmlViewer(QWidget):
 
         self.setLayout(main_layout)
         self.setWindowTitle('Edit Anking Tables')
-        self.setWindowIcon(QIcon(os.path.join(os.path.dirname(__file__), 'icons', 'table_editor_gui_dark.png' if is_night_mode else 'table_editor_gui_light.png')))
+        self.setWindowIcon(QIcon(os.path.join(os.path.dirname(__file__), 'icons', 'table_editor_gui_dark.png' if is_night_mode() else 'table_editor_gui_light.png')))
         self.setGeometry(*self.calculate_geometry())
         self.show()
 
@@ -165,7 +165,7 @@ class HtmlEditor(QTextEdit):
         self.setPlainText(initial_html)
         self.setContentsMargins(20, 10, 0, 10)
         font = QFont()
-        font.setPointSize(12.5)
+        font.setPointSize(12)
         self.setFont(font)
         self.highlighter = HtmlHighlighter(self.document())
 
@@ -189,6 +189,10 @@ class HtmlEditor(QTextEdit):
         underline_shortcut = QShortcut(QKeySequence("Ctrl+U"), self)
         underline_shortcut.activated.connect(self.underline)
 
+        # Add Ctrl+T shortcut for toggling cell header
+        toggle_shortcut = QShortcut(QKeySequence("Ctrl+T"), self)
+        toggle_shortcut.activated.connect(self.toggle_cell_header)
+
     def bold(self):
         self.wrap_selected_text_with_tag('b')
 
@@ -197,6 +201,53 @@ class HtmlEditor(QTextEdit):
 
     def underline(self):
         self.wrap_selected_text_with_tag('u')
+
+    def toggle_cell_header(self):
+        """Toggle the <td>/<th> tag of the cell where the cursor is currently placed."""
+        cursor = self.textCursor()
+        pos = cursor.position()
+        text = self.toPlainText()
+        lower = text.lower()
+
+        before_lower = lower[:pos]
+        td_pos = before_lower.rfind('<td')
+        th_pos = before_lower.rfind('<th')
+
+        if td_pos == -1 and th_pos == -1:
+            return
+
+        if td_pos > th_pos:
+            current_tag = 'td'
+            tag_start = td_pos
+        else:
+            current_tag = 'th'
+            tag_start = th_pos
+
+        new_tag = 'th' if current_tag == 'td' else 'td'
+
+        tag_end = text.find('>', tag_start)
+        if tag_end == -1:
+            return
+        tag_end += 1
+
+        close_tag = f'</{current_tag}>'
+        close_pos = lower.find(close_tag, tag_end)
+        if close_pos == -1:
+            return
+
+        opening = text[tag_start:tag_end]
+        new_opening = re.sub(r'(?i)^<' + current_tag, f'<{new_tag}', opening)
+
+        new_text = (text[:tag_start] +
+                    new_opening +
+                    text[tag_end:close_pos] +
+                    f'</{new_tag}>' +
+                    text[close_pos + len(close_tag):])
+
+        self.setPlainText(new_text)
+        new_cursor = self.textCursor()
+        new_cursor.setPosition(pos)
+        self.setTextCursor(new_cursor)
 
     def wrap_selected_text_with_tag(self, tag):
         cursor = self.textCursor()
@@ -213,49 +264,58 @@ class TopToolbar(QHBoxLayout):
         self.add_toolbar_buttons()
 
     def add_toolbar_buttons(self):
-        buttons = [
-            QPushButton(),
-            QPushButton(),
-            QPushButton(),
-            QPushButton(),
-            QPushButton(),
-            QPushButton(),
-        ]
-        for i, button in enumerate(buttons):
-            button.setFixedSize(25, 25)
-            if i == 0:
-                button.clicked.connect(lambda: self.parent.central_widget.htmlEditor.setPlainText(self.parent.initial_html))
-                button.setIcon(QIcon(os.path.join(os.path.dirname(__file__), 'icons','reset_dark.png' if is_night_mode else 'reset_light.png')))
-                button.setToolTip("Reset to original table")
-            elif i == 1:
-                button.clicked.connect(lambda: button1_func(self.parent))
-                button.setIcon(QIcon(os.path.join(os.path.dirname(__file__), 'icons', 'header_row_dark.png' if is_night_mode else 'header_row_light.png')))
-                button.setToolTip("Convert to table with a header row ONLY")
-            elif i == 2:
-                button.clicked.connect(lambda: button2_func(self.parent))
-                button.setIcon(QIcon(os.path.join(os.path.dirname(__file__), 'icons', 'header_row_column_dark.png' if is_night_mode else 'header_row_column_light.png')))
-                button.setToolTip("Convert to table with a header row & column")
-            elif i == 3:
-                button.clicked.connect(lambda: self.parent.central_widget.htmlEditor.bold())
-                button.setIcon(QIcon(os.path.join(os.path.dirname(__file__), 'icons', 'bold_dark.png' if is_night_mode else 'bold_light.png')))
-                button.setToolTip("Bold")
-            elif i == 4:
-                button.clicked.connect(lambda: self.parent.central_widget.htmlEditor.italic())
-                button.setIcon(QIcon(os.path.join(os.path.dirname(__file__), 'icons', 'italic_dark.png' if is_night_mode else 'italic_light.png')))
-                button.setToolTip("Italic")
-            elif i == 5:
-                button.clicked.connect(lambda: self.parent.central_widget.htmlEditor.underline())
-                button.setIcon(QIcon(os.path.join(os.path.dirname(__file__), 'icons', 'underline_dark.png' if is_night_mode else 'underline_light.png')))
-                button.setToolTip("Underline")
-            self.addWidget(button)
-            if i == 0 or i == 2:
-                try:
-                    # PyQt6
-                    spacer = QSpacerItem(20, 10, QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Minimum)
-                except AttributeError:
-                    # PyQt5
-                    spacer = QSpacerItem(20, 10, QSizePolicy.Fixed, QSizePolicy.Minimum)
-                self.addItem(spacer)
+        def make_btn(tooltip, callback, dark_icon=None, light_icon=None, text=None, width=25):
+            btn = QPushButton()
+            btn.setFixedSize(width, 25)
+            if dark_icon:
+                btn.setIcon(QIcon(os.path.join(os.path.dirname(__file__), 'icons',
+                                               dark_icon if is_night_mode() else light_icon)))
+            if text:
+                btn.setText(text)
+            btn.setToolTip(tooltip)
+            btn.clicked.connect(callback)
+            self.addWidget(btn)
+
+        def add_spacer():
+            try:
+                self.addItem(QSpacerItem(20, 10, QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Minimum))
+            except AttributeError:
+                self.addItem(QSpacerItem(20, 10, QSizePolicy.Fixed, QSizePolicy.Minimum))
+
+        make_btn("Reset to original table",
+                 lambda: self.parent.central_widget.htmlEditor.setPlainText(self.parent.initial_html),
+                 'reset_dark.png', 'reset_light.png')
+        add_spacer()
+
+        make_btn("Convert to table with a header row ONLY",
+                 lambda: button1_func(self.parent),
+                 'header_row_dark.png', 'header_row_light.png')
+
+        make_btn("Convert to table with a header row & column",
+                 lambda: button2_func(self.parent),
+                 'header_row_column_dark.png', 'header_row_column_light.png')
+
+        make_btn("Convert to table with a header column ONLY (no header row)",
+                 lambda: button3_func(self.parent),
+                 text="Col", width=30)
+        add_spacer()
+
+        make_btn("Bold",
+                 lambda: self.parent.central_widget.htmlEditor.bold(),
+                 'bold_dark.png', 'bold_light.png')
+
+        make_btn("Italic",
+                 lambda: self.parent.central_widget.htmlEditor.italic(),
+                 'italic_dark.png', 'italic_light.png')
+
+        make_btn("Underline",
+                 lambda: self.parent.central_widget.htmlEditor.underline(),
+                 'underline_dark.png', 'underline_light.png')
+
+        make_btn("Toggle header formatting for current cell (Ctrl+T)",
+                 lambda: self.parent.central_widget.htmlEditor.toggle_cell_header(),
+                 text="Th")
+
         self.addStretch(1)
 
 
@@ -331,7 +391,6 @@ class CentralWidget(QFrame):
         vbox = QVBoxLayout()
         vbox.setContentsMargins(0, 0, 0, 0)
         vbox.addWidget(self.htmlEditor)
-        vbox.addWidget(self.webView)
 
         central_layout.addLayout(vbox, 40)
         central_layout.addWidget(self.webView, 60)
@@ -343,16 +402,14 @@ class CentralWidget(QFrame):
         # Remove the old table tags
         current_tags = [tag for tag in note.tags if tag.startswith('!AK_UpdateTags::Table::')]
 
-        # Get the updated tag
-        updated_tag = "!AK_UpdateTags::Table::" + self.parent.bottom_buttons.tag_edit.text().replace(' ', '_')
-
-        # Check if old_tags is empty or updated_tag is not in old_tags
-        if not current_tags or updated_tag not in current_tags:
-            # Remove all old tags
-            for old_tag in current_tags:
-                note.remove_tag(old_tag)
-            # Add the updated tag to the note
-            note.add_tag(updated_tag)
+        # Get the updated tag — skip entirely if the tag field is empty
+        tag_text = self.parent.bottom_buttons.tag_edit.text().strip().replace(' ', '_')
+        if tag_text:
+            updated_tag = "!AK_UpdateTags::Table::" + tag_text
+            if not current_tags or updated_tag not in current_tags:
+                for old_tag in current_tags:
+                    note.remove_tag(old_tag)
+                note.add_tag(updated_tag)
 
         # Replace the first table in the field with the updated table
         soup = BeautifulSoup(note[field_name], "html.parser")
@@ -480,6 +537,23 @@ def button2_func(parent):
     soup = BeautifulSoup(html, 'html.parser')
     for table in soup.find_all('table'):
         process_table(table)
+        headerize_first_column(parent.editor, soup)
+    new_html = str(soup)
+    parent.central_widget.htmlEditor.setPlainText(new_html)
+    parent.set_html(new_html)
+
+
+def button3_func(parent):
+    """Convert to table with a header column ONLY (no header row)."""
+    html = parent.central_widget.htmlEditor.toPlainText()
+    soup = BeautifulSoup(html, 'html.parser')
+    for table in soup.find_all('table'):
+        skip_rows = process_table(table)
+        # Undo the header row(s) that process_table always creates
+        rows = table.find_all('tr')
+        for row in rows[:skip_rows]:
+            for cell in row.find_all('th'):
+                cell.name = 'td'
         headerize_first_column(parent.editor, soup)
     new_html = str(soup)
     parent.central_widget.htmlEditor.setPlainText(new_html)

--- a/src/anking_tables/utils.py
+++ b/src/anking_tables/utils.py
@@ -134,5 +134,6 @@ def is_night_mode():
 
 def search_text(text):
     browser = dialogs.open("Browser", mw)
-    browser.form.searchEdit.lineEdit().setText(text)
+    safe_text = text.replace('"', '\\"')
+    browser.form.searchEdit.lineEdit().setText(f'"{safe_text}"')
     browser.onSearchActivated()


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Addresses all 5 open bug reports and both open enhancement issues.

### Bugs fixed

- **Issue #12** — `font.setPointSize(12.5)` crashes with `TypeError` on PyQt 6.9+ because the method only accepts `int`. Changed to `12`.
- **`is_night_mode` missing `()` (silent bug)** — `is_night_mode` is a function but was used as a bare name in 7 places, so it always evaluated as truthy (a function object). Dark-mode icons were shown regardless of the actual theme. Fixed all call sites in `main_window.py` and `__init__.py`.
- **Issue #9** — Clicking Apply with an empty tag field added a malformed `!AK_UpdateTags::Table::` tag (shown as "blank"). Tag update is now skipped entirely when the field is empty.
- **Issue #8** — The "Search for Table" button extracted plain text from the table and sent it unquoted to Anki's browser search. Special characters like `-`, `,`, and Unicode letters broke the parser and returned zero results. The text is now wrapped in double quotes (`"..."`) so Anki treats it as a phrase search.
- **Layout bug (CentralWidget)** — `webView` was added to both `vbox` and `central_layout`. Qt silently moves a widget when it's added to a second layout, so `webView` was removed from `vbox` on the second `addWidget` call, leaving `htmlEditor` alone in that column with no companion. Removed the redundant `vbox.addWidget(self.webView)`.

### Enhancements

- **Issue #11** — New **"Col"** toolbar button: converts the table to have a header column only (no header row). Calls `process_table` to clean styling, undoes the header row it always creates, then calls `headerize_first_column`.
- **Issue #10** — New **"Th"** toolbar button + **Ctrl+T** shortcut: toggles `<td>` ↔ `<th>` for whichever cell the cursor is currently inside in the HTML editor. Uses `rfind` to locate the nearest opening tag before the cursor and `find` to locate its closing tag, then swaps both.

### Toolbar refactor

`add_toolbar_buttons` was rewritten from a `for`-loop with `if/elif` chains into a small `make_btn` helper. This was necessary to add the new buttons cleanly and to ensure `is_night_mode()` is called correctly each time a button is created.

## Test plan

- [ ] Open addon on a card with a table — verify it opens without `TypeError` crash (Issue #12)
- [ ] Toggle between light/dark mode in Anki — verify toolbar icons switch correctly (is_night_mode fix)
- [ ] Click Apply with empty tag field — verify no new tag is added to the note (Issue #9)
- [ ] Click "Search for Table" on a table with special characters — verify cards are returned (Issue #8)
- [ ] Verify the HTML editor and preview pane appear side-by-side as expected (layout fix)
- [ ] Click "Col" button — verify first column becomes `<th>` cells with no header row
- [ ] Place cursor inside a `<td>` cell, press Ctrl+T or click "Th" — verify it becomes `<th>` and vice versa (Issue #10)

https://claude.ai/code/session_01ScBTSaesYG75Z6temfdHQf
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ScBTSaesYG75Z6temfdHQf)_